### PR TITLE
Updating Travis CI configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: ruby
 rvm:
+  - 2.3.1
   - 2.1.2
+
+before_install:
+  - gem update bundler
+
 script: bundle exec rspec


### PR DESCRIPTION
Travis-CI is using a broken version of Bundler for Ruby 2.1.2, so force an update.
Also adding the latest Ruby release to the build table.
