### PR TITLE
WIP: Add Contracts Gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,7 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
+require 'yard'
+require 'yard-contracts'
+
+YARD::Rake::YardocTask.new do |t|
+  t.files   = %w{lib/**/*.rb}
+end

--- a/lib/remedy/ansi.rb
+++ b/lib/remedy/ansi.rb
@@ -1,9 +1,13 @@
+require 'contracts'
 require 'remedy/console'
 
 module Remedy
   module ANSI
     module_function
+    include Contracts::Core
+    include Contracts::Builtin
 
+    Contract Args[Or[String,ArrayOf[String]]] => Any
     def push *sequences
       Console.output << sequences.join('')
     end

--- a/lib/remedy/console_resize.rb
+++ b/lib/remedy/console_resize.rb
@@ -1,5 +1,10 @@
+# Using this syntax instead of Remedy::Console::Resize
+# because this file doesn't actually rely on any other file
+# so it can be use completely in isolation
 module Remedy; module Console; module Resize
   module_function
+  include Contracts::Core
+  include Contracts::Builtin
 
   def resizing?
     @resize_count > 0
@@ -21,6 +26,7 @@ module Remedy; module Console; module Resize
     @resize_count == 1
   end
 
+  Contract Proc => Any
   def set_console_resized_hook!
     @resize_count = 0
 

--- a/lib/remedy/size.rb
+++ b/lib/remedy/size.rb
@@ -1,5 +1,11 @@
+require 'contracts'
+
 module Remedy
   class Size
+    include Contracts::Core
+    include Contracts::Builtin
+
+    Contract Args[Or[Num, ArrayOf[Num], Range, ArrayOf[Range]]] => Any
     def initialize *new_dimensions
       new_dimensions.flatten!
       if new_dimensions.first.is_a? Range then

--- a/lib/remedy/viewport.rb
+++ b/lib/remedy/viewport.rb
@@ -1,3 +1,4 @@
+require 'contracts'
 require 'remedy/view'
 require 'remedy/size'
 require 'remedy/content'
@@ -6,6 +7,9 @@ require 'remedy/ansi'
 
 module Remedy
   class Viewport
+    include Contracts::Core
+    include Contracts::Builtin
+
     def draw content, center = Size.new(0,0), header = [], footer = []
       range = range_find content, center, content_size(header,footer)
 
@@ -21,6 +25,7 @@ module Remedy
       Console.output << view
     end
 
+    Contract Partial, Size, Size => ArrayOf[Range]
     def range_find partial, center, heightwidth
       row_size, col_size = heightwidth
       row_limit, col_limit = partial.size

--- a/remedy.gemspec
+++ b/remedy.gemspec
@@ -18,5 +18,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
+  gem.add_dependency 'contracts'
   gem.add_development_dependency 'rspec'
 end

--- a/remedy.gemspec
+++ b/remedy.gemspec
@@ -20,4 +20,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'contracts'
   gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'yard-contracts'
+  gem.add_development_dependency 'yard'
 end


### PR DESCRIPTION
The [`contracts` gem](https://egonschiele.github.io/contracts.ruby/) provides a terse syntax for writing method guards. Other advantages include better error messages for both developers and endusers as well as the ability to generate documentation using the [`yard-contracts` gem](https://github.com/sfcgeorge/yard-contracts).

It can be considered a form of gradual typing and by default provides type-based constraints, but it can also be used for any other kind of constraints which can be determined at runtime.

The downside is that currently `remedy` has no runtime dependencies outside of Ruby's standard library and this would introduce quite a bit of magic to the codebase. On the other hand, it should be trivial to extract (delete) since no code will depend on it, except that there will be less hard-coded guards.

Documentation:

- [Builtin Contracts on RelishApp](https://www.relishapp.com/contracts-staging/contracts-ruby/docs/builtin-contracts)
- [API Documentation on RubyDoc](http://www.rubydoc.info/gems/contracts/Contract)